### PR TITLE
chore: allow docs workflow to read actions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,6 +7,7 @@ on:
     branches: [ main ]
 
 permissions:
+  actions: read
   contents: read
   pages: write
   id-token: write


### PR DESCRIPTION
## Summary
- permit docs workflow to read GitHub actions

## Testing
- `./build.sh` *(fails: Could not find Eigen3 package)*
- `sudo apt-get update && sudo apt-get install -y libeigen3-dev` *(fails: 403 Forbidden while fetching packages)*
- `act -n push -W .github/workflows/docs.yml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b28e823da483329a1a08f5df24791e