### PR TITLE
Add foundational geometry primitives and tests

### DIFF
--- a/include/geom.hpp
+++ b/include/geom.hpp
@@ -2,10 +2,17 @@
 
 // Core
 #include "geom/core/config.hpp"
+#include "geom/core/predicates.hpp"
 
 // Primitives
+#include "geom/primitives/point.hpp"
+#include "geom/primitives/line.hpp"
+#include "geom/primitives/segment.hpp"
 #include "geom/primitives/ray.hpp"
+#include "geom/primitives/plane.hpp"
 #include "geom/primitives/triangle.hpp"
+#include "geom/primitives/aabb.hpp"
+#include "geom/primitives/obb.hpp"
 
 // Algorithms
 #include "geom/algorithms/intersect.hpp"

--- a/include/geom/core/predicates.hpp
+++ b/include/geom/core/predicates.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "geom/primitives/point.hpp"
+
+namespace geom {
+
+inline Scalar orient2d(const Vec2& a, const Vec2& b, const Vec2& c) {
+    return (b.x() - a.x()) * (c.y() - a.y()) - (b.y() - a.y()) * (c.x() - a.x());
+}
+
+inline Scalar orient3d(const Vec3& a, const Vec3& b, const Vec3& c, const Vec3& d) {
+    Vec3 ad = a - d;
+    Vec3 bd = b - d;
+    Vec3 cd = c - d;
+    return ad.dot(bd.cross(cd));
+}
+
+} // namespace geom
+

--- a/include/geom/primitives/aabb.hpp
+++ b/include/geom/primitives/aabb.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <Eigen/Geometry>
+
+#include "geom/primitives/point.hpp"
+
+namespace geom {
+
+using AABB3d = Eigen::AlignedBox<Scalar, 3>;
+
+inline Vec3 project_point(const AABB3d& box, const Vec3& p) {
+    return p.cwiseMax(box.min()).cwiseMin(box.max());
+}
+
+inline Scalar signed_distance(const AABB3d& box, const Vec3& p) {
+    Vec3 c = box.center();
+    Vec3 e = box.sizes() / Scalar(2);
+    Vec3 q = (p - c).cwiseAbs() - e;
+    Vec3 q_clamped = q.cwiseMax(Vec3::Zero());
+    return q_clamped.norm() + std::min(q.maxCoeff(), Scalar(0));
+}
+
+} // namespace geom
+

--- a/include/geom/primitives/line.hpp
+++ b/include/geom/primitives/line.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <Eigen/Geometry>
+
+#include "geom/primitives/point.hpp"
+
+namespace geom {
+
+using Line3d = Eigen::ParametrizedLine<Scalar, 3>;
+
+inline Line3d line_from_points(const Vec3& a, const Vec3& b) {
+    return Line3d::Through(a, b);
+}
+
+} // namespace geom
+

--- a/include/geom/primitives/obb.hpp
+++ b/include/geom/primitives/obb.hpp
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <algorithm>
+#include <array>
+
+#include "geom/primitives/point.hpp"
+
+namespace geom {
+
+struct OBB3d {
+    Vec3 center{Vec3::Zero()};
+    std::array<Vec3,3> axes{Vec3::UnitX(), Vec3::UnitY(), Vec3::UnitZ()};
+    Vec3 half_extents{Vec3::Ones()*Scalar(0.5)};
+
+    bool contains(const Vec3& p) const {
+        Vec3 d = p - center;
+        for(int i=0;i<3;++i) {
+            Scalar dist = d.dot(axes[i]);
+            if (std::abs(dist) > half_extents[i]) return false;
+        }
+        return true;
+    }
+
+    Vec3 project_point(const Vec3& p) const {
+        Vec3 d = p - center;
+        Vec3 result = center;
+        for(int i=0;i<3;++i) {
+            Scalar dist = d.dot(axes[i]);
+            Scalar clamped = std::clamp(dist, -half_extents[i], half_extents[i]);
+            result += clamped * axes[i];
+        }
+        return result;
+    }
+
+    Scalar signed_distance(const Vec3& p) const {
+        Vec3 d = p - center;
+        Vec3 q;
+        for(int i=0;i<3;++i) {
+            Scalar dist = d.dot(axes[i]);
+            q[i] = std::abs(dist) - half_extents[i];
+        }
+        Vec3 q_pos = q.cwiseMax(Vec3::Zero());
+        Scalar outside = q_pos.norm();
+        Scalar inside = std::min(q.maxCoeff(), Scalar(0));
+        return outside + inside;
+    }
+};
+
+} // namespace geom
+

--- a/include/geom/primitives/plane.hpp
+++ b/include/geom/primitives/plane.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <Eigen/Geometry>
+
+#include "geom/primitives/point.hpp"
+
+namespace geom {
+
+using Plane3d = Eigen::Hyperplane<Scalar, 3>;
+
+inline Plane3d plane_from_point_normal(const Vec3& p, const Vec3& n) {
+    Vec3 nn = n.normalized();
+    return Plane3d(nn, -nn.dot(p));
+}
+
+inline Plane3d plane_from_points(const Vec3& a, const Vec3& b, const Vec3& c) {
+    Vec3 n = (b - a).cross(c - a).normalized();
+    return Plane3d(n, -n.dot(a));
+}
+
+} // namespace geom
+

--- a/include/geom/primitives/point.hpp
+++ b/include/geom/primitives/point.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <Eigen/Core>
+
+#include "geom/core/config.hpp"
+
+namespace geom {
+
+using Vec2 = Eigen::Matrix<Scalar, 2, 1>;
+using Vec3 = Eigen::Matrix<Scalar, 3, 1>;
+
+using Point2d = Vec2;
+using Point3d = Vec3;
+
+} // namespace geom
+

--- a/include/geom/primitives/segment.hpp
+++ b/include/geom/primitives/segment.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <algorithm>
+
+#include "geom/primitives/point.hpp"
+
+namespace geom {
+
+struct Segment3d {
+    Vec3 a{Vec3::Zero()};
+    Vec3 b{Vec3::UnitX()};
+
+    Vec3 project_point(const Vec3& p) const {
+        Vec3 ab = b - a;
+        Scalar t = ab.dot(p - a) / ab.squaredNorm();
+        t = std::clamp(t, Scalar(0), Scalar(1));
+        return a + t * ab;
+    }
+
+    Scalar distance(const Vec3& p) const {
+        return (p - project_point(p)).norm();
+    }
+
+    Scalar length() const { return (b - a).norm(); }
+};
+
+} // namespace geom
+

--- a/include/geom/primitives/triangle.hpp
+++ b/include/geom/primitives/triangle.hpp
@@ -27,6 +27,9 @@ struct Triangle3d final {
     Vec3 barycentric_to_cartesian(Scalar u, Scalar v, Scalar w) const;
     Vec3 barycentric_to_cartesian(Scalar u, Scalar v) const; // w = 1 - u - v
 
+    // Convert cartesian point to barycentric coordinates (u,v,w)
+    Vec3 cartesian_to_barycentric(const Vec3& p) const;
+
     // Check if barycentric coordinates are within triangle bounds
     bool contains_point_barycentric(Scalar u, Scalar v, Scalar tolerance = Scalar(1e-6)) const;
 

--- a/src/primitives/triangle.cpp
+++ b/src/primitives/triangle.cpp
@@ -45,4 +45,20 @@ Triangle3d Triangle3d::create_equilateral(const Vec3& center, Scalar side_length
     return tri;
 }
 
+Triangle3d::Vec3 Triangle3d::cartesian_to_barycentric(const Vec3& p) const {
+    Vec3 v0 = b - a;
+    Vec3 v1 = c - a;
+    Vec3 v2 = p - a;
+    Scalar d00 = v0.dot(v0);
+    Scalar d01 = v0.dot(v1);
+    Scalar d11 = v1.dot(v1);
+    Scalar d20 = v2.dot(v0);
+    Scalar d21 = v2.dot(v1);
+    Scalar denom = d00 * d11 - d01 * d01;
+    Scalar v = (d11 * d20 - d01 * d21) / denom;
+    Scalar w = (d00 * d21 - d01 * d20) / denom;
+    Scalar u = Scalar(1) - v - w;
+    return Vec3(u, v, w);
+}
+
 } // namespace geom

--- a/tests/test_primitives_gtest.cpp
+++ b/tests/test_primitives_gtest.cpp
@@ -1,7 +1,14 @@
 #include <gtest/gtest.h>
+#include <random>
 
+#include "geom/primitives/line.hpp"
+#include "geom/primitives/segment.hpp"
 #include "geom/primitives/ray.hpp"
+#include "geom/primitives/plane.hpp"
 #include "geom/primitives/triangle.hpp"
+#include "geom/primitives/aabb.hpp"
+#include "geom/primitives/obb.hpp"
+#include "geom/core/predicates.hpp"
 
 using namespace geom;
 
@@ -88,4 +95,91 @@ TEST_F(TriangleTest, EquilateralTriangle) {
     Scalar eq_area = eq_tri.area();
     Scalar expected_area = std::sqrt(Scalar(3.0)); // Area of equilateral triangle with side 2
     EXPECT_NEAR(eq_area, expected_area, 1e-5);
+}
+
+TEST_F(TriangleTest, CartesianToBarycentric) {
+    auto coords = tri.cartesian_to_barycentric(tri.centroid());
+    EXPECT_NEAR(coords[0], Scalar(1.0/3.0), 1e-6);
+    EXPECT_NEAR(coords[1], Scalar(1.0/3.0), 1e-6);
+    EXPECT_NEAR(coords[2], Scalar(1.0/3.0), 1e-6);
+}
+
+TEST_F(TriangleTest, BarycentricRoundTripRandom) {
+    std::mt19937 gen(42);
+    std::uniform_real_distribution<Scalar> dist(0.0, 1.0);
+    for(int i=0;i<100;i++) {
+        Scalar u = dist(gen);
+        Scalar v = dist(gen);
+        if(u + v > Scalar(1)) { u = Scalar(1) - u; v = Scalar(1) - v; }
+        Scalar w = Scalar(1) - u - v;
+        auto p = tri.barycentric_to_cartesian(u,v,w);
+        auto coords = tri.cartesian_to_barycentric(p);
+        EXPECT_NEAR(coords[0], u, 1e-5);
+        EXPECT_NEAR(coords[1], v, 1e-5);
+        EXPECT_NEAR(coords[2], w, 1e-5);
+    }
+}
+
+TEST(LineTest, Projection) {
+    Line3d line(Vec3::Zero(), Vec3::UnitX());
+    Vec3 p(1,1,0);
+    auto proj = line.projection(p);
+    EXPECT_NEAR(proj.y(), 0.0, 1e-6);
+}
+
+TEST(LineTest, ProjectionRandom) {
+    std::mt19937 gen(123);
+    std::uniform_real_distribution<Scalar> dist(-1.0,1.0);
+    for(int i=0;i<100;i++) {
+        Vec3 a(dist(gen), dist(gen), dist(gen));
+        Vec3 b(dist(gen), dist(gen), dist(gen));
+        if((b-a).norm() < 1e-6) continue;
+        Line3d line = line_from_points(a,b);
+        Vec3 p(dist(gen), dist(gen), dist(gen));
+        Vec3 proj = line.projection(p);
+        Vec3 v = p - proj;
+        EXPECT_NEAR(v.dot(line.direction()), 0.0, 1e-5);
+    }
+}
+
+TEST(SegmentTest, Distance) {
+    Segment3d seg;
+    seg.a = Vec3(0,0,0);
+    seg.b = Vec3(1,0,0);
+    Vec3 p(0.5,1,0);
+    EXPECT_NEAR(seg.distance(p), 1.0, 1e-6);
+}
+
+TEST(PlaneTest, SignedDistance) {
+    Plane3d plane = plane_from_point_normal(Vec3::Zero(), Vec3::UnitZ());
+    Vec3 p(0,0,5);
+    EXPECT_NEAR(plane.signedDistance(p), 5.0, 1e-6);
+    auto proj = plane.projection(p);
+    EXPECT_NEAR(proj.z(), 0.0, 1e-6);
+}
+
+TEST(AABBTest, ProjectionAndDistance) {
+    AABB3d box(Vec3(-1,-1,-1), Vec3(1,1,1));
+    Vec3 p(2,0,0);
+    auto proj = project_point(box, p);
+    EXPECT_NEAR(proj.x(), 1.0, 1e-6);
+    EXPECT_NEAR(signed_distance(box, p), 1.0, 1e-6);
+    EXPECT_TRUE(signed_distance(box, Vec3(0,0,0)) <= 0);
+}
+
+TEST(OBBTest, Projection) {
+    OBB3d box; box.center = Vec3::Zero(); box.half_extents = Vec3(1,2,3);
+    Vec3 p(3,0,0);
+    auto proj = box.project_point(p);
+    EXPECT_NEAR((proj - Vec3(1,0,0)).norm(), 0.0, 1e-6);
+}
+
+TEST(PredicateTest, Orientation2D) {
+    Vec2 a(0,0), b(1,0), c(0,1);
+    EXPECT_GT(orient2d(a,b,c), 0);
+}
+
+TEST(PredicateTest, Orientation3D) {
+    Vec3 a(0,0,0), b(1,0,0), c(0,1,0), d(0,0,1);
+    EXPECT_GT(orient3d(a,b,c,d), 0);
 }


### PR DESCRIPTION
## Summary
- replace custom line, plane, and AABB structures with Eigen's ParametrizedLine, Hyperplane, and AlignedBox
- provide helper constructors (line_from_points, plane_from_point_normal) and update tests accordingly

## Testing
- `./build.sh` *(fails: Could not find package configuration file provided by "Eigen3" )*

------
https://chatgpt.com/codex/tasks/task_e_68b2aed8f3b083329074e3d132257b10