### PR TITLE
Add line and segment intersection utilities with result types

### DIFF
--- a/include/geom/algorithms/intersect.hpp
+++ b/include/geom/algorithms/intersect.hpp
@@ -2,9 +2,11 @@
 
 // std
 #include <limits>
+#include <cmath>
 
 #include "geom/primitives/ray.hpp"
 #include "geom/primitives/triangle.hpp"
+#include "geom/algorithms/results.hpp"
 
 namespace geom {
 
@@ -50,5 +52,41 @@ inline RayTriHit intersect(const Ray3d& r, const Triangle3d& tri) {
 RayTriHit intersect_moller_trumbore(const Ray3d& r, const Triangle3d& tri, Scalar epsilon = Scalar(1e-9));
 bool ray_intersects_triangle(const Ray3d& r, const Triangle3d& tri, Scalar epsilon = Scalar(1e-9));
 Scalar distance_ray_to_triangle(const Ray3d& r, const Triangle3d& tri);
+
+// 2D line-line intersection. Lines defined by two points each.
+// Returns parameters on each line and intersection point.
+inline IntersectResult<2> intersect_lines(const Vec2& p0, const Vec2& p1,
+                                          const Vec2& q0, const Vec2& q1,
+                                          Scalar epsilon = Scalar(1e-9)) {
+    const Vec2 r = p1 - p0;
+    const Vec2 s = q1 - q0;
+    const Scalar denom = r.x() * s.y() - r.y() * s.x();
+    if (std::abs(denom) < epsilon) return {}; // parallel
+    const Vec2 qp = q0 - p0;
+    const Scalar t = (qp.x() * s.y() - qp.y() * s.x()) / denom; // on first
+    const Scalar u = (qp.x() * r.y() - qp.y() * r.x()) / denom; // on second
+    IntersectResult<2> res;
+    res.hit = true;
+    res.paramA = t;
+    res.paramB = u;
+    res.point = p0 + t * r;
+    return res;
+}
+
+// 2D segment-segment intersection. Returns hit only when intersection is
+// within both segments (inclusive).
+inline IntersectResult<2> intersect_segments(const Vec2& a0, const Vec2& a1,
+                                             const Vec2& b0, const Vec2& b1,
+                                             Scalar epsilon = Scalar(1e-9)) {
+    auto res = intersect_lines(a0, a1, b0, b1, epsilon);
+    if (!res.hit) return res;
+    if (res.paramA < Scalar(0) - epsilon || res.paramA > Scalar(1) + epsilon) {
+        return {};
+    }
+    if (res.paramB < Scalar(0) - epsilon || res.paramB > Scalar(1) + epsilon) {
+        return {};
+    }
+    return res;
+}
 
 }  // namespace geom

--- a/include/geom/algorithms/intersect.hpp
+++ b/include/geom/algorithms/intersect.hpp
@@ -63,13 +63,18 @@ inline IntersectResult<2> intersect_lines(const Vec2& a0, const Vec2& a1,
 
     // Check if lines are parallel (or nearly parallel)
     if (std::abs(cross) < epsilon) {
-        // Lines are collinear - check if they overlap
+        // Check if lines are collinear by seeing if a0 lies on line B
         const Vec2 r = a0 - b0;
-        const Scalar dot1 = r.dot(dir_b);
-        // const Scalar dot2 = dir_a.dot(dir_b);
+        const Scalar cross_r = r[0] * dir_b[1] - r[1] * dir_b[0];
 
-        // If lines are collinear, return a valid hit with collinear flag
-        return {true, true, Scalar(0), dot1 / dir_b.squaredNorm(), a0};
+        if (std::abs(cross_r) < epsilon) {
+            // Lines are collinear - return hit with collinear flag
+            const Scalar dot1 = r.dot(dir_b);
+            return {true, true, Scalar(0), dot1 / dir_b.squaredNorm(), a0};
+        } else {
+            // Lines are parallel but not collinear - no intersection
+            return {false, false, Scalar(0), Scalar(0), {}};
+        }
     }
 
     // Lines intersect at a single point

--- a/include/geom/algorithms/results.hpp
+++ b/include/geom/algorithms/results.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <limits>
+
+#include "geom/primitives/point.hpp"
+
+namespace geom {
+
+/** Result of intersection queries. Stores parameters on each primitive
+ * and the computed intersection point if any. */
+template<int Dim>
+struct IntersectResult {
+    bool hit{false};
+    Scalar paramA{Scalar(0)}; ///< Parameter on first primitive
+    Scalar paramB{Scalar(0)}; ///< Parameter on second primitive
+    Eigen::Matrix<Scalar, Dim, 1> point{Eigen::Matrix<Scalar, Dim, 1>::Zero()};
+};
+
+/** Result of distance queries. Contains closest points and distance. */
+template<int Dim>
+struct DistanceResult {
+    Scalar distance{std::numeric_limits<Scalar>::infinity()};
+    Eigen::Matrix<Scalar, Dim, 1> closestA{Eigen::Matrix<Scalar, Dim, 1>::Zero()};
+    Eigen::Matrix<Scalar, Dim, 1> closestB{Eigen::Matrix<Scalar, Dim, 1>::Zero()};
+};
+
+} // namespace geom
+

--- a/include/geom/algorithms/results.hpp
+++ b/include/geom/algorithms/results.hpp
@@ -11,6 +11,7 @@ namespace geom {
 template<int Dim>
 struct IntersectResult {
     bool hit{false};
+    bool collinear{false};
     Scalar paramA{Scalar(0)}; ///< Parameter on first primitive
     Scalar paramB{Scalar(0)}; ///< Parameter on second primitive
     Eigen::Matrix<Scalar, Dim, 1> point{Eigen::Matrix<Scalar, Dim, 1>::Zero()};

--- a/src/algorithms/intersect.cpp
+++ b/src/algorithms/intersect.cpp
@@ -1,11 +1,11 @@
 #include "geom/algorithms/intersect.hpp"
+
+// std
 #include <cmath>
 
 namespace geom {
 
 RayTriHit intersect_moller_trumbore(const Ray3d& r, const Triangle3d& tri, Scalar epsilon) {
-    using Vec3 = Eigen::Matrix<Scalar, 3, 1>;
-    
     const Vec3 edge1 = tri.b - tri.a;
     const Vec3 edge2 = tri.c - tri.a;
     const Vec3 pvec = r.dir.cross(edge2);
@@ -19,7 +19,7 @@ RayTriHit intersect_moller_trumbore(const Ray3d& r, const Triangle3d& tri, Scala
     const Scalar invDet = Scalar(1) / det;
     const Vec3 tvec = r.origin - tri.a;
     const Scalar u = tvec.dot(pvec) * invDet;
-    
+
     // Check if intersection point is outside triangle (u < 0 or u > 1)
     if (u < Scalar(0) - epsilon || u > Scalar(1) + epsilon) {
         return RayTriHit{};
@@ -27,14 +27,14 @@ RayTriHit intersect_moller_trumbore(const Ray3d& r, const Triangle3d& tri, Scala
 
     const Vec3 qvec = tvec.cross(edge1);
     const Scalar v = r.dir.dot(qvec) * invDet;
-    
+
     // Check if intersection point is outside triangle (v < 0 or u + v > 1)
     if (v < Scalar(0) - epsilon || u + v > Scalar(1) + epsilon) {
         return RayTriHit{};
     }
 
     const Scalar t = edge2.dot(qvec) * invDet;
-    
+
     // Check if intersection is behind ray origin
     if (t < Scalar(0)) {
         return RayTriHit{};

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,6 +5,7 @@ add_executable(geometry_gtests)
 target_sources(geometry_gtests PRIVATE
     test_primitives_gtest.cpp
     test_intersect_gtest.cpp
+    test_segment_intersection_gtest.cpp
 )
 
 # Link with geometry library and GTest

--- a/tests/test_intersect_gtest.cpp
+++ b/tests/test_intersect_gtest.cpp
@@ -79,3 +79,17 @@ TEST_F(IntersectionTest, MollerTrumboreWithCustomEpsilon) {
     EXPECT_TRUE(hit.hit);
     EXPECT_NEAR(hit.t, 1.0, 1e-6);
 }
+
+TEST(IntersectionAdversarial, SliverTriangle) {
+    Ray3d r;
+    r.origin = Ray3d::Vec3(0.0, 0.1, -1.0);
+    r.dir = Ray3d::Vec3(0.0, 0.0, 1.0);
+
+    Triangle3d tri;
+    tri.a = Triangle3d::Vec3(0.0, 0.0, 0.0);
+    tri.b = Triangle3d::Vec3(1e-9, 0.0, 0.0); // sliver edge
+    tri.c = Triangle3d::Vec3(0.0, 1.0, 0.0);
+
+    auto hit = intersect(r, tri);
+    EXPECT_TRUE(hit.hit);
+}

--- a/tests/test_segment_intersection_gtest.cpp
+++ b/tests/test_segment_intersection_gtest.cpp
@@ -28,4 +28,3 @@ TEST(SegmentSegment, NearlyParallelIntersection) {
     EXPECT_NEAR(hit.point.x(), 0.5, 1e-6);
     EXPECT_NEAR(hit.point.y(), 0.5e-8, 1e-10);
 }
-

--- a/tests/test_segment_intersection_gtest.cpp
+++ b/tests/test_segment_intersection_gtest.cpp
@@ -28,3 +28,27 @@ TEST(SegmentSegment, NearlyParallelIntersection) {
     EXPECT_NEAR(hit.point.x(), 0.5, 1e-6);
     EXPECT_NEAR(hit.point.y(), 0.5e-8, 1e-10);
 }
+
+TEST(SegmentSegment, CollinearSharingEndpoint) {
+    // Test the original issue: segments a0=(0,0)–a1=(1,0) and b0=(1,0)–b1=(2,0)
+    // These should intersect at point (1,0)
+    Vec2 a0(0, 0), a1(1, 0);
+    Vec2 b0(1, 0), b1(2, 0);
+    auto hit = intersect_segments(a0, a1, b0, b1);
+    ASSERT_TRUE(hit.hit);
+    EXPECT_TRUE(hit.collinear);
+    EXPECT_NEAR(hit.point.x(), 1.0, 1e-6);
+    EXPECT_NEAR(hit.point.y(), 0.0, 1e-6);
+}
+
+TEST(SegmentSegment, CollinearOverlapping) {
+    // Test overlapping collinear segments
+    Vec2 a0(0, 0), a1(2, 0);
+    Vec2 b0(1, 0), b1(3, 0);
+    auto hit = intersect_segments(a0, a1, b0, b1);
+    ASSERT_TRUE(hit.hit);
+    EXPECT_TRUE(hit.collinear);
+    // Should report intersection at the start of the overlap
+    EXPECT_NEAR(hit.point.x(), 1.0, 1e-6);
+    EXPECT_NEAR(hit.point.y(), 0.0, 1e-6);
+}

--- a/tests/test_segment_intersection_gtest.cpp
+++ b/tests/test_segment_intersection_gtest.cpp
@@ -1,0 +1,31 @@
+#include <gtest/gtest.h>
+
+#include "geom/algorithms/intersect.hpp"
+
+using namespace geom;
+
+TEST(SegmentSegment, BasicIntersection) {
+    Vec2 a0(0, 0), a1(1, 0);
+    Vec2 b0(0.5, -1), b1(0.5, 1);
+    auto hit = intersect_segments(a0, a1, b0, b1);
+    ASSERT_TRUE(hit.hit);
+    EXPECT_NEAR(hit.point.x(), 0.5, 1e-6);
+    EXPECT_NEAR(hit.point.y(), 0.0, 1e-6);
+}
+
+TEST(SegmentSegment, ParallelNoIntersection) {
+    Vec2 a0(0, 0), a1(1, 0);
+    Vec2 b0(0, 1), b1(1, 1);
+    auto hit = intersect_segments(a0, a1, b0, b1);
+    EXPECT_FALSE(hit.hit);
+}
+
+TEST(SegmentSegment, NearlyParallelIntersection) {
+    Vec2 a0(0, 0), a1(1, 1e-8);
+    Vec2 b0(0, 1e-8), b1(1, 0);
+    auto hit = intersect_segments(a0, a1, b0, b1);
+    ASSERT_TRUE(hit.hit);
+    EXPECT_NEAR(hit.point.x(), 0.5, 1e-6);
+    EXPECT_NEAR(hit.point.y(), 0.5e-8, 1e-10);
+}
+


### PR DESCRIPTION
## Summary
- Introduce `IntersectResult` and `DistanceResult` templates for consistent query output
- Implement 2D line-line and segment-segment intersection helpers
- Add adversarial tests for near-parallel segments and sliver triangles

## Testing
- `cmake -S . -B build` *(fails: Could not find package configuration file provided by "Eigen3")*
- `apt-get install -y libeigen3-dev` *(fails: Unable to locate package libeigen3-dev)*

------
https://chatgpt.com/codex/tasks/task_e_68b35842c1dc8332bf03e528a395a867